### PR TITLE
Added sorting by year and month, latest date first.

### DIFF
--- a/modules/custom/og_ext_cron/src/Utils/CronFunctions.php
+++ b/modules/custom/og_ext_cron/src/Utils/CronFunctions.php
@@ -683,6 +683,10 @@ class CronFunctions {
         \Drupal::logger('cron')->notice("$missingIndexItemsCounter requests not matched. ATI Summaries not found in the core_ati index...");
       }
 
+      usort($rows, function($a, $b){
+        return -1 * ([$a['year'], $a['month']] <=> [$b['year'], $b['month']]);
+      });
+
       $this->write_to_csv(
         'ati-informal-requests-analytics.csv',
         $rows,


### PR DESCRIPTION
The ATI informal requests analytics csv does not have any sorting to it based on year and month. This just adds that via a PHP usort, reversing the return of the spaceship comparison on the years and months.